### PR TITLE
Proximity behaviour

### DIFF
--- a/saviSimulation/savi/asl/working.asl
+++ b/saviSimulation/savi/asl/working.asl
@@ -6,7 +6,8 @@
 
 // Set initial beliefs and test goals
 pi(3.14159265359).			// Set the constant for PI
-proximityThreshold(30.0).
+proximityThreshold(30.0).	// When the agent is closer than this threashold, no need to get closer
+targetLastRight.
 
 /* Rules */
 
@@ -69,9 +70,16 @@ targetFar :-
 
 // Plan for trying to find a target
 +!findTarget
-	:	noTarget
+	:	noTarget & targetLastRight
+	<-	turn(right);
+		.broadcast(tell,turning(right)).
+		
+// Plan for trying to find a target
++!findTarget
+	:	noTarget & targetLastLeft
 	<-	turn(left);
 		.broadcast(tell,turning(left)).
+	
 +!findTarget.
 
 // Default plan for observing target - force recursion.
@@ -89,12 +97,16 @@ targetFar :-
 +!faceTarget
 	:	targetRight
 	<-	turn(right);
+		+targetLastRight;
+		-targetLastLeft;
 		.broadcast(tell,turning(right)).
 		
 // Face a target to the left
 +!faceTarget
 	:	targetLeft
 	<-	turn(left);
+		+targetLastLeft;
+		-targetLastRight;
 		.broadcast(tell,turning(left)).
 		
 // Face a target, goal achieved


### PR DESCRIPTION
Make the agent stop moving when it gets close to the target (try to not go running past it).

Also, try to make the agent turn the direction it last saw a target. Mostly works. Will upgrade to better solution when new turn action is implemented.