### PR TITLE
Fixes issue with mailbox growing exponentially

### DIFF
--- a/saviSimulation/savi/StateSynchronization/SyncAgentState.java
+++ b/saviSimulation/savi/StateSynchronization/SyncAgentState.java
@@ -132,6 +132,7 @@ public class SyncAgentState {
 	public synchronized Queue<String> getMsgIn() {
 		Queue<String> myCopy = new LinkedList<String>();
 		myCopy.addAll(msgIn);
+		msgIn.clear();
 		return myCopy;
 	}
 


### PR DESCRIPTION
The broadcast messages being sent to the agents do not clear out after being processed by each reasoning cycle. The mailbox grows exponentially and causes the agents to stall/freeze due to too many messages.

Could I get someone to make sure that this won't break anything else?